### PR TITLE
feat(ci): add support for ESP-IDF v4.4 in Docker and CI workflow

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         target:
+          - esp-idf-v4.4
           - esp-idf-v5.2
           - esp-idf-v5.3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,36 @@ RUN apt install -y gcc-arm-none-eabi binutils-arm-none-eabi
 # ESP-IDF Prerequisites
 RUN apt install -y git wget flex bison gperf python3 python3-venv cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0
 
+FROM base AS esp-idf-v4.4
+
+RUN apt install -y python3-pip python3-setuptools python3-virtualenv clangd
+
+# Get ESP-IDF
+ARG ESP_IDF_VERSION=v4.4.5
+RUN cd /opt && git clone -b ${ESP_IDF_VERSION} --recursive https://github.com/espressif/esp-idf.git
+
+USER ${USER_NAME}
+
+# ESP-IDF Set up the tools
+RUN cd /opt/esp-idf && ./install.sh esp32
+
+RUN echo "export IDF_PATH=/opt/esp-idf" >> /home/${USER_NAME}/.bashrc && \
+    echo "source /opt/esp-idf/export.sh" >> /home/${USER_NAME}/.bashrc && \
+    echo "PS1='(docker)esp-idf-${ESP_IDF_VERSION}:\w${PS1}'" >> /home/${USER_NAME}/.bashrc
+
+USER root
+RUN set -e; \
+    cat > /usr/local/bin/clangd-with-idf <<'EOF' && chmod +x /usr/local/bin/clangd-with-idf
+#!/usr/bin/env bash
+set -euo pipefail
+# Load ESP-IDF environment (adds esp-clang/clangd to PATH)
+source /opt/esp-idf/export.sh >/dev/null 2>&1
+LOG=/tmp/clangd.log
+: > "$LOG" || { echo "cannot write $LOG" >&2; exit 1; }
+exec clangd --background-index --header-insertion-decorators=0 --query-driver="/home/*/.espressif/tools/*/*/bin/*,/opt/esp-idf/tools/*/*/bin/*,/usr/bin/*" "$@" --log=verbose 2>>"$LOG"
+EOF
+USER ${USER_NAME}
+
 FROM base AS esp-idf-v5.3
 
 # Get ESP-IDF


### PR DESCRIPTION
- Updated GitHub Actions workflow to include ESP-IDF v4.4 in the build matrix
- Added Dockerfile stage for ESP-IDF v4.4 with necessary dependencies and setup
- Included a custom `clangd-with-idf` script for ESP-IDF v4.4 development