### PR TITLE
feat(ci): add step to free disk space in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -23,6 +23,17 @@ jobs:
           - esp-idf-v5.3
 
     steps:
+      - name: Free disk space on runner
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - uses: actions/checkout@v4
 
       - name: Install jq


### PR DESCRIPTION
- Integrated jlumbroso/free-disk-space action to optimize runner storage
- Enabled cleanup for tool cache, Android, .NET, Haskell, and Docker images
- Added swap storage cleanup to ensure sufficient disk space during builds