### PR TITLE
feat(Dockerfile): add support for ESP-IDF v5.5 setup

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -21,6 +21,7 @@ jobs:
           - esp-idf-v4.4
           - esp-idf-v5.2
           - esp-idf-v5.3
+          - esp-idf-v5.5
 
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,34 @@ exec clangd --background-index --header-insertion-decorators=0 --query-driver="/
 EOF
 USER ${USER_NAME}
 
+FROM base AS esp-idf-v5.5
+
+# Get ESP-IDF
+ARG ESP_IDF_VERSION=v5.5.1
+RUN cd /opt && git clone -b ${ESP_IDF_VERSION} --recursive https://github.com/espressif/esp-idf.git
+
+USER ${USER_NAME}
+
+# ESP-IDF Set up the tools
+RUN cd /opt/esp-idf && ./install.sh esp32 && python3 ./tools/idf_tools.py install esp-clang
+
+RUN echo "export IDF_PATH=/opt/esp-idf" >> /home/${USER_NAME}/.bashrc && \
+    echo "source /opt/esp-idf/export.sh" >> /home/${USER_NAME}/.bashrc && \
+    echo "PS1='(docker)esp-idf-${ESP_IDF_VERSION}:\w${PS1}'" >> /home/${USER_NAME}/.bashrc
+
+USER root
+RUN set -e; \
+    cat > /usr/local/bin/clangd-with-idf <<'EOF' && chmod +x /usr/local/bin/clangd-with-idf
+#!/usr/bin/env bash
+set -euo pipefail
+# Load ESP-IDF environment (adds esp-clang/clangd to PATH)
+source /opt/esp-idf/export.sh >/dev/null 2>&1
+LOG=/tmp/clangd.log
+: > "$LOG" || { echo "cannot write $LOG" >&2; exit 1; }
+exec clangd --background-index --header-insertion-decorators=0 --query-driver="/home/*/.espressif/tools/*/*/bin/*,/opt/esp-idf/tools/*/*/bin/*,/usr/bin/*" "$@" --log=verbose 2>>"$LOG"
+EOF
+USER ${USER_NAME}
+
 FROM base AS esp-idf-v5.3
 
 # Get ESP-IDF


### PR DESCRIPTION
- Add a new Docker build stage for ESP-IDF v5.5
- Clone ESP-IDF repository at version v5.5.1 with submodules
- Install ESP-IDF tools and esp-clang
- Configure environment variables and shell setup for ESP-IDF
- Add a wrapper script for clangd with ESP-IDF integration